### PR TITLE
[tests] Bump TestSelect1 socket timeout to 1ms

### DIFF
--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -263,7 +263,7 @@ namespace MonoTests.System.Net.Sockets
 				ArrayList list = new ArrayList ();
 				ArrayList empty = new ArrayList ();
 				list.Add (acc);
-				Socket.Select (list, empty, empty, 100);
+				Socket.Select (list, empty, empty, 1000);
 				Assert.AreEqual (0, empty.Count, "#01");
 				Assert.AreEqual (1, list.Count, "#02");
 				Socket.Select (empty, list, empty, 100);


### PR DESCRIPTION
- Previous test with 100 micro second timeout would fail on iOS device when running **all the socket tests** about 3 times out of 5.
- With a 1 millisecond timeout, it didn't fail the 10 times I tried locally, hopefully this is enough to fix the flakiness.
- Fixes #8360: [System.Net.Sockets] flakey failures of SocketTest.TestSelect1 on Darwin systems
  (https://github.com/mono/mono/issues/8360)
- Also partial fix for maccore issue https://github.com/xamarin/maccore/issues/1069



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
